### PR TITLE
Regenerate requirements.txt. Handle CLI args for ingesting parameters

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+output
+__pycache__


### PR DESCRIPTION
@acferris 
Adding ability to pass parameter file path or json as a CLI argument while falling back to a defined `parameterFile` variable in the running environment.

Lastly, added an option to specify an `outputDir`, defaulting to `./output`.