### PR TITLE
only run main analysis when base.py is called directly as main script

### DIFF
--- a/base.py
+++ b/base.py
@@ -220,8 +220,9 @@ def loadParameters(parameterFile):
     
     return minSample, minloci, umapSeed, epsilon, cutHeight, admixedCutoff, filePrefix, inputCountsFile, inputMetaFile
 
-minSample, minloci, umapSeed, epsilon, cutHeight, admixedCutoff, filePrefix, inputCountsFile, inputMetaFile = loadParameters(parameterFile)
-snpProportion, snpProportionNoInterpolation, sampleMeta = filterData(inputCountsFile, inputMetaFile, minloci, minSample)
-embedding = embedData(snpProportion, umapSeed)
-db_communities = clusteringDBSCAN(snpProportion, sampleMeta, embedding, epsilon, filePrefix, admixedCutoff)
-output = labelSamples(snpProportion, sampleMeta, db_communities, embedding, cutHeight, admixedCutoff, filePrefix)
+if __name__ == '__main__':
+    minSample, minloci, umapSeed, epsilon, cutHeight, admixedCutoff, filePrefix, inputCountsFile, inputMetaFile = loadParameters(parameterFile)
+    snpProportion, snpProportionNoInterpolation, sampleMeta = filterData(inputCountsFile, inputMetaFile, minloci, minSample)
+    embedding = embedData(snpProportion, umapSeed)
+    db_communities = clusteringDBSCAN(snpProportion, sampleMeta, embedding, epsilon, filePrefix, admixedCutoff)
+    output = labelSamples(snpProportion, sampleMeta, db_communities, embedding, cutHeight, admixedCutoff, filePrefix)


### PR DESCRIPTION
@acferris 
Just adding this little change to avoid running the main analysis when I import functions from the base.py within my code.
`from clusteringForVarietyIdentification.base import filterData, embedData, clusteringDBSCAN, labelSamples`
