### PR TITLE
include reference column lookup for heatmapReferences

### DIFF
--- a/graphs.py
+++ b/graphs.py
@@ -307,7 +307,7 @@ def heatmapReferences(snpProportion, sampleMeta, allVarieties, tick_type):
         tickType: 'inventory' (inventory number), 'short_name' (sample number), 'divergence' (label divergence score), 'source' (sample source), 'references' (reference name)
     """
     
-    refShort = sampleMeta[np.isin(sampleMeta['reference_original'],allVarieties)]['short_name'].values.astype('str')
+    refShort = sampleMeta[np.isin(sampleMeta['reference_original'],allVarieties) | np.isin(sampleMeta['reference'],allVarieties)]['short_name'].values.astype('str')
     refShort = refShort[np.isin(refShort.astype(str), snpProportion.columns)]
     subset = snpProportion[refShort].values
     subsetReorder, clusterOrder, breakPoints = clusterReorder(subset, [subset.shape[1]])


### PR DESCRIPTION
include reference column in addition to reference_original column when looking up varieties for heatmapReferences

Hey @acferris. List of varieties in output used in post-processing are derived from the 'reference' column, whereas heatmapReferences looks up the passed in varieties against the 'reference_original' column. Lookup returns empty where the two columns differ in value. This PR/change looks up varieties in both columns. I'll merge this preemptively. Let me know if there are concerns around this you may have. 

Hope all is well on your end, cheers! 