### PR TITLE
Fix python error when computing heterozygosity

### DIFF
--- a/base.py
+++ b/base.py
@@ -158,7 +158,7 @@ def labelSamples(snpProportion,sampleMeta,db_communities,embedding, cutHeight, a
     output['missingness'] = ((snpProportionNoInterpolation.isna().sum(axis = 0)[snpProportion.columns])/snpProportionNoInterpolation.shape[1]).values
     
     #add heterozygosity
-    output['heterozygosity'] = (((0.05 < snpProportion < 0.95).sum(axis = 0)) / snpProportion.shape[0]).values
+    output['heterozygosity'] = (((snpProportion > 0.05) & (snpProportion < 0.95)).sum(axis=0) / snpProportion.shape[0]).values
     
     output.to_csv(filePrefix+'_clusteringOutputData_cutHeight'+str(cutHeight)+'.csv', index=False)
     


### PR DESCRIPTION
@acferris Minor fix to circumvent the python error being thrown on your latest heterozygosity computation.

I was receiving the following error:
```
Exception has occurred: ValueError       (note: full exception trace is shown but execution is paused at: ClusterAnalysis)
The truth value of a DataFrame is ambiguous. Use a.empty, a.bool(), a.item(), a.any() or a.all().
  File "/Users/cagdasbayram/projects/image/backend/analysis/clusteringForVarietyIdentification/base.py", line 161, in labelSamples
    output['heterozygosity'] = (((0.05 < snpProportion < 0.95).sum(axis = 0)) / snpProportion.shape[0]).values
                                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/cagdasbayram/projects/image/backend/analysis/grpc_server.py", line 52, in ClusterAnalysis (Current frame)
    output, output2 = labelSamples(snpProportion, sampleMeta, communities, embedding, cutHeight, admixedCutoff, tmpFilePrefix, snpProportionNoInterpolation, tmpParameterFile)
                      ~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
ValueError: The truth value of a DataFrame is ambiguous. Use a.empty, a.bool(), a.item(), a.any() or a.all().
```