### PR TITLE
bugfix specify cutHeight instead of cutLine on plot

### DIFF
--- a/graphs.py
+++ b/graphs.py
@@ -585,7 +585,7 @@ def dendrogram(snpProportion, sampleMeta, communities, COI, cutHeight, tick_type
     plt.figure(figsize=(14.4,4.8))
     sch.dendrogram(Y_cluster, labels = labels, color_threshold = cutHeight) #sample names
     if cutLine:
-        plt.plot([0,10*clusterSubset.shape[1]],[cutLine, cutLine],'k')
+        plt.plot([0,10*clusterSubset.shape[1]],[cutHeight, cutHeight],'k')
     plt.tight_layout()
 
 def umapReleaseYear(snpProportion, sampleMeta, embedding):
@@ -736,7 +736,7 @@ def heatmapDendrogram(snpProportion, sampleMeta, communities, COI, cutHeight, cu
     ax1 = plt.subplot(gs[0,1])
     sch.dendrogram(Y_cluster, color_threshold = cutHeight, no_labels = True)
     if cutLine:
-        plt.plot([0,10*clusterSubset.shape[1]],[cutLine, cutLine],'k')
+        plt.plot([0,10*clusterSubset.shape[1]],[cutHeight, cutHeight],'k')
     ax1.set_title('Cluster '+str(COI))
 
     #heatmap half


### PR DESCRIPTION
@acferris Another fix. The horizontal line wasn't showing up. Changed it to be the cutHeight instead of the cutLine on the plot. 
<img width="630" alt="Screenshot 2025-03-03 at 4 13 32 PM" src="https://github.com/user-attachments/assets/40dff10d-f8ab-4540-940e-96487dbc89fc" />
