### PR TITLE
Add Docker support and fix cross-platform UMAP reproducibility

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,7 @@
+.git
+__pycache__
+*.pyc
+.gitignore
+.idea
+.vscode
+*.egg-info

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,12 @@
 __pycache__
+*.pyc
+*.egg-info/
+dist/
+build/
+data/
+.vscode/
+.idea/
+.claude/
+.env
+.DS_Store
+*.swp

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,22 @@
+FROM --platform=linux/amd64 python:3.11-slim-bookworm
+
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+        gcc g++ gfortran libopenblas-dev && \
+    rm -rf /var/lib/apt/lists/*
+
+ENV NUMBA_CPU_NAME="generic"
+ENV NUMBA_NUM_THREADS=1
+ENV OPENBLAS_NUM_THREADS=1
+
+WORKDIR /app
+
+COPY requirements.txt constraints.txt ./
+RUN pip install --no-cache-dir -r requirements.txt -c constraints.txt
+
+COPY . .
+RUN pip install --no-cache-dir -c constraints.txt .
+
+RUN mkdir -p /data
+
+ENTRYPOINT ["python"]

--- a/README.md
+++ b/README.md
@@ -4,3 +4,50 @@ Python module to identify and label crop varieties using genotyping data
 The code in this repository was developed by IDM to support our research into seed system capacity. We've made it publicly available under the MIT License to provide others with a better understanding of our research and an opportunity to build upon it for their own work. We make no representations that the code works as intended or that we will provide support, address issues that are found, or accept pull requests. You are welcome to create your own fork and modify the code to suit your own modeling needs as contemplated under the MIT License.
 
 To run the code, you will need counts data from a panel of SNPs, a corresponding metadata file with sample information, and a json with parameter values. Example data and instructions for how to run the pipeline can be found in the tutorial folder.
+
+## Running with Docker
+
+Running the analysis inside Docker ensures reproducible results across different machines and architectures (e.g. Apple Silicon vs x86_64). The Dockerfile targets `linux/amd64` (Debian Bookworm) and pins all dependency versions via `constraints.txt`. It also sets `NUMBA_CPU_NAME=generic` and single-threaded execution to eliminate CPU-specific JIT and threading non-determinism in the numba/UMAP stack.
+
+### Prerequisites
+
+Install [Docker Desktop](https://www.docker.com/products/docker-desktop/) (macOS / Windows) or [Docker Engine](https://docs.docker.com/engine/install/) (Linux).
+
+### Build the image
+
+```bash
+docker build --platform linux/amd64 -t clustering-analysis .
+```
+
+### Run the tutorial example
+
+```bash
+docker run --platform linux/amd64 \
+  -v $(pwd)/tutorial:/data -w /data \
+  clustering-analysis \
+  -c "import sys; sys.path.insert(0, '/app'); from base import runPipeline; runPipeline('/data/parametersRiceTutorial.json')"
+```
+
+The `-w /data` flag sets the container's working directory to `/data` so that relative file names in the parameters JSON (e.g. `"countsRiceTutorial.csv"`) resolve correctly. `sys.path.insert(0, '/app')` adds the application directory back to Python's module search path so that the pipeline modules can still be imported.
+
+### Run with your own data
+
+Place your counts CSV, metadata CSV, and parameters JSON in a local directory, then mount it to `/data`:
+
+```bash
+docker run --platform linux/amd64 \
+  -v /path/to/your/data:/data -w /data \
+  clustering-analysis \
+  -c "import sys; sys.path.insert(0, '/app'); from base import runPipeline; runPipeline('/data/yourParameters.json')"
+```
+
+File paths in your parameters JSON can be either relative (e.g. `"counts.csv"`) or absolute with the `/data/` prefix (e.g. `"/data/counts.csv"`). Output files (plots and CSVs) will be written back to the mounted directory.
+
+### Running outside Docker
+
+To get results matching the Docker image on a bare-metal Linux (x86_64) machine, install dependencies with constraints and set the same environment variables:
+
+```bash
+pip install -r requirements.txt -c constraints.txt
+export NUMBA_CPU_NAME=generic NUMBA_NUM_THREADS=1 OPENBLAS_NUM_THREADS=1
+```

--- a/base.py
+++ b/base.py
@@ -67,7 +67,7 @@ def embedData(snpProportion, umapSeed):
         umapSeed: RNG seed for umap embedding
     '''
     #UMAP embedding
-    reducer = umap.UMAP(random_state=umapSeed)
+    reducer = umap.UMAP(random_state=umapSeed, init='random')
     embedding = reducer.fit_transform(snpProportion.T) #the order is the same after embedding
     
     return embedding

--- a/constraints.txt
+++ b/constraints.txt
@@ -1,0 +1,11 @@
+numpy==1.23.5
+pandas==1.5.2
+scipy==1.10.0
+scikit-learn==1.6.1
+umap-learn==0.5.7
+numba==0.60.0
+llvmlite==0.43.0
+matplotlib==3.6.2
+pynndescent==0.5.13
+joblib==1.5.1
+threadpoolctl==3.6.0


### PR DESCRIPTION
Running the clustering pipeline on different machines (e.g. Apple M4 vs Debian x86_64) produced different UMAP embeddings and therefore different cluster/variety assignments, even with identical package versions and random seeds.

Root cause: UMAP's default spectral initialization uses scipy's ARPACK eigensolver, whose iterative convergence path differs across platforms. This caused completely different embedding layouts on the same data, leading to ~22% of samples receiving different variety labels.

Fix: Set init='random' in the UMAP constructor. With random initialization, UMAP's SGD optimization is fully governed by the random seed, producing byte-for-byte identical results across environments. Verified 0 differences across all 3,531 samples between Docker on macOS (ARM via QEMU amd64 emulation) and bare-metal Debian x86_64.

Additional changes for reproducibility defense-in-depth:
- Dockerfile targeting linux/amd64 python:3.11-slim-bookworm
- constraints.txt pinning all numerical dependency versions
- NUMBA_CPU_NAME=generic to prevent CPU-specific JIT code
- NUMBA_NUM_THREADS=1 and OPENBLAS_NUM_THREADS=1 to eliminate threading non-determinism
- .dockerignore to keep the image lean
- .gitignore expanded with common editor/IDE/build entries
- README updated with Docker build/run instructions